### PR TITLE
Whoops, need to actually build the image we run

### DIFF
--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -1,5 +1,9 @@
 # NOTE: currently requires SCM triggering due to dependency on the COMMIT_SHA variable
 steps:
+  # Build and tag using commit sha
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '.', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/pop-stats/pop-stats:${COMMIT_SHA}', '-f', 'Dockerfile']
+    dir: 'app'
   # Run api tests
   - name: 'us-central1-docker.pkg.dev/$PROJECT_ID/pop-stats/pop-stats:${COMMIT_SHA}'
     entrypoint: python


### PR DESCRIPTION
Looks like the tests need to run within the image that would later be deployed