### PR TITLE
Enable deploy security insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ The demo will be used to display:
 - [x] Cloud Deploy deploy to test
 - [x] Cloud Deploy promotion across environments
 - [x] Image scanning
-- [] Provenance generation
+- [x] Cloud Build security insights
+- [x] Provenance generation
+- [x] Cloud Deploy security insights
 - [] Cloud Deploy canary deployment
 - [] Cloud Deploy label to link back to git sha
 - [] DORA stats (Cloud Deploy?)
-- [] Security insights in Cloud Deploy (can show cloud build panel at least, ideally both)
 - [] Binauthz gating of deployment
 
 ## Setup tutorial
@@ -90,6 +91,9 @@ You must give Cloud Build explicit permission to trigger a Google Cloud Deploy r
 3. Add these two roles
   * Cloud Deploy Releaser
   * Service Account User
+  * Making "gcloud artifacts docker images describe" work:
+    * Container Analysis Admin + service agent (probably overkill?)
+    * Artifact registry reader (???)
 
 You must give the service account that runs your kubernetes workloads
 permission to pull containers from artifact registry:
@@ -148,6 +152,11 @@ the `test` environment.  You can see the progress via the
 In the [Google Cloud Deploy UI](https://console.cloud.google.com/deploy/delivery-pipelines),
 you can promote the release from test to staging, and from staging to prod (with a manual
 approval step in between).
+
+## Security insights
+
+* View Cloud Build security insights via the Cloud Build history view: https://cloud.google.com/build/docs/view-build-security-insights
+* View Cloud Deploy security insights via the release artifacts view: https://cloud.google.com/deploy/docs/securing/security-insights
 
 ## Demo Overview
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,17 +13,20 @@ steps:
   # Push the container image to Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'
     args: ['push', 'us-central1-docker.pkg.dev/$PROJECT_ID/pop-stats/pop-stats:${COMMIT_SHA}']
-  # Create release in Google Cloud Deploy
+  # Create release in Google Cloud Deploy using the digest of the newly built image
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: gcloud
-    args: 
-      [
-        "deploy", "releases", "create", "rel-${SHORT_SHA}",
-        "--delivery-pipeline", "pop-stats-pipeline",
-        "--region", "us-central1",
-        "--annotations", "commitId=${REVISION_ID}",
-        "--images", "pop-stats=us-central1-docker.pkg.dev/$PROJECT_ID/pop-stats/pop-stats:${COMMIT_SHA}"
-      ]
+    entrypoint: bash
+    args:
+    - -c
+    - |
+      gcloud artifacts docker images describe \
+        'us-central1-docker.pkg.dev/$PROJECT_ID/pop-stats/pop-stats:${COMMIT_SHA}' \
+        --format 'value(image_summary.digest)' > digest
+      gcloud deploy releases create rel-${SHORT_SHA} \
+        --delivery-pipeline pop-stats-pipeline \
+        --region us-central1 \
+        --annotations commitId=${REVISION_ID} \
+        --images pop-stats=us-central1-docker.pkg.dev/$PROJECT_ID/pop-stats/pop-stats:${COMMIT_SHA}@$(cat digest)
 images:
 - us-central1-docker.pkg.dev/$PROJECT_ID/pop-stats/pop-stats:${COMMIT_SHA}
 options:


### PR DESCRIPTION
Need to specify image digest when creating release https://cloud.google.com/deploy/docs/securing/security-insights